### PR TITLE
[docs] Update documentation for features from 2026-04-04

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ export BOTSTRAP_ROOT="$(pwd)"
 - [Registry specification](docs/REGISTRY_SPEC.md)
 - [Tool selection](docs/TOOL_SELECTION.md)
 - [Cross-platform notes](docs/CROSS_PLATFORM.md)
-- [AI agent friendliness](docs/AI_AGENT_FRIENDLINESS.md)
+- [AI agent friendliness](docs/AI_AGENT_FRIENDLINESS.md) — including automated doc maintenance via the `daily-doc-updater` workflow
 - [Contributing](docs/CONTRIBUTING.md)
 
 ## Version

--- a/docs/AI_AGENT_FRIENDLINESS.md
+++ b/docs/AI_AGENT_FRIENDLINESS.md
@@ -43,6 +43,38 @@ Phase 2 lets users opt into **Claude Code**, **OpenClaw**, **Codex CLI**, **Gemi
 - Piping unaudited remote scripts without reading them first (same as for humans).
 - Assuming GUI-only installers; Botstrap should prefer winget/brew/apt where possible.
 
+## Automated documentation maintenance
+
+Botstrap uses a **GitHub Copilot agentic workflow** to keep project documentation up to date automatically.
+
+### `daily-doc-updater` workflow
+
+Defined in `.github/workflows/daily-doc-updater.md`, this workflow runs on a daily schedule and:
+
+1. Scans merged pull requests and significant commits from the last 24 hours.
+2. Analyzes changes for new features, removed features, modified behavior, and breaking changes.
+3. Reviews existing documentation in `docs/` and `README.md` for gaps.
+4. Updates the appropriate documentation file(s) to reflect new functionality.
+5. Opens a pull request (with labels `documentation` and `automation`) for human review before merging.
+
+The workflow is powered by [GitHub Copilot agentic workflows](https://github.github.com/gh-aw/introduction/overview/) (`gh aw`). The compiled GitHub Actions workflow is stored in `daily-doc-updater.lock.yml` (auto-generated — do not edit directly). Regenerate with:
+
+```bash
+gh aw compile
+```
+
+### Agentics maintenance
+
+`agentics-maintenance.yml` runs every 6 hours to close expired agentic pull requests and issues (based on the `expires: 2d` setting in the `daily-doc-updater` safe-outputs configuration). It also supports manual `workflow_dispatch` operations (`disable`, `enable`, `update`, `upgrade`, `safe_outputs`, `create_labels`).
+
+### Lock files
+
+`.gitattributes` marks `*.lock.yml` workflow files as linguist-generated so they are excluded from language stats and treated as generated files for diffs:
+
+```gitattributes
+.github/workflows/*.lock.yml linguist-generated=true merge=ours
+```
+
 ## Extending for agents
 
 When adding a tool:


### PR DESCRIPTION
Add a new 'Automated documentation maintenance' section to docs/AI_AGENT_FRIENDLINESS.md covering:
- daily-doc-updater workflow (schedule, behavior, regeneration)
- agentics-maintenance.yml (expiration handling, manual ops)
- .gitattributes lock-file convention

Update README.md to surface the AI_AGENT_FRIENDLINESS doc with a brief note about automated documentation maintenance.