### PR TITLE
[docs] Update documentation for features from 2026-04-06

### DIFF
--- a/docs/AFTER_INSTALL.md
+++ b/docs/AFTER_INSTALL.md
@@ -63,6 +63,8 @@ When **`zellij`** is in **`core_tools`**, Phase 3 installs it and on **Windows**
 
 Core install includes **mise**. Optional language rows run **`mise use --global …`** with PATH including **`~/.local/bin`** (Unix) or **`%LOCALAPPDATA%\mise\bin`** and **`%USERPROFILE%\.local\bin`** (Windows). Check **`mise ls`** and **`mise current`**.
 
+**`uv`** (Astral's fast Python package and project manager) is also installed automatically during the **`mise` post_install** step, alongside Node and Python. It is available on PATH after opening a new shell. Verify with **`uv --version`**.
+
 ### Docker database images
 
 If you selected databases, Phase 3 pulls images such as **`postgres:16-alpine`**, **`mysql:8`**, **`redis:7-alpine`**. They are not started automatically. Run containers with **`docker run`** or Compose per [Docker documentation](https://docs.docker.com/).

--- a/docs/TOOL_SELECTION.md
+++ b/docs/TOOL_SELECTION.md
@@ -25,7 +25,7 @@ Git, curl, jq, yq, and gum are defined in **`registry/prerequisites.yaml`** so t
 
 | Tool | Rationale |
 |------|-----------|
-| **mise** | Single tool for Node, Python, Ruby, Go, and more; replaces nvm/pyenv/rbenv fragmentation and keeps PATH deterministic for agents. |
+| **mise** | Single tool for Node, Python, Ruby, Go, and more; replaces nvm/pyenv/rbenv fragmentation and keeps PATH deterministic for agents. **`uv`** (fast Python package manager) is installed alongside mise automatically. |
 
 ### Containers
 


### PR DESCRIPTION
uv (Astral's fast Python package manager) is now installed automatically as part of the mise post_install step on both Unix and Windows. Update AFTER_INSTALL.md and TOOL_SELECTION.md to reflect this.